### PR TITLE
Added basic parsing functionality

### DIFF
--- a/src/expressions.js
+++ b/src/expressions.js
@@ -30,6 +30,10 @@ Expression.prototype.copy = function() {
     return copy;
 };
 
+Expression.prototype.isConstant = function() {
+    return this.terms.length == 0 && !!this.constant;
+};
+
 Expression.prototype.add = function(a) {
     var thisExp = this.copy();
 
@@ -62,7 +66,7 @@ Expression.prototype.add = function(a) {
     } else if (isInt(a) || a instanceof Fraction) {
         thisExp.constant = thisExp.constant.add(a);
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 
     thisExp._removeTermsWithCoefficientZero();
@@ -90,8 +94,8 @@ Expression.prototype.subtract = function(a) {
         inverse = -a;
     } else if (a instanceof Fraction) {
         inverse = a.multiply(-1);
-    } else {
-        throw "InvalidArgument";
+    } else {        
+        throw Error("InvalidArgument");
     }
 
     return thisExp.add(inverse);
@@ -139,7 +143,7 @@ Expression.prototype.multiply = function(a) {
             thisExp.terms[i].coefficient = thisExp.terms[i].coefficient.multiply(a);
         }
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 
     return thisExp;
@@ -148,7 +152,7 @@ Expression.prototype.multiply = function(a) {
 Expression.prototype.divide = function(a) {
     if (a instanceof Fraction || isInt(a)) {
         if (a == 0) {
-            throw "DivideByZero";
+            throw Error("DivideByZero");
         }
 
         var copy = this.copy();
@@ -161,7 +165,7 @@ Expression.prototype.divide = function(a) {
 
         return copy;
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 };
 
@@ -180,7 +184,7 @@ Expression.prototype.pow = function(a) {
             return copy;
         }
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 };
 
@@ -410,7 +414,7 @@ Term = function(variable) {
     } else if (typeof(variable) === "undefined") {
         this.variables = [];
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 
     this.coefficient = new Fraction(1, 1);
@@ -434,7 +438,7 @@ Term.prototype.add = function(term) {
         copy.coefficient = copy.coefficient.add(term.coefficient);
         return copy;
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 };
 
@@ -444,7 +448,7 @@ Term.prototype.subtract = function(term) {
         copy.coefficient = copy.coefficient.subtract(term.coefficient);
         return copy;
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 };
 
@@ -472,7 +476,7 @@ Term.prototype.multiply = function(a) {
     } else if(isInt(a) || a instanceof Fraction) {
         thisTerm.coefficient = thisTerm.coefficient.multiply(a);
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 
     return thisTerm.sort();
@@ -484,7 +488,7 @@ Term.prototype.divide = function(a) {
         thisTerm.coefficient = thisTerm.coefficient.divide(a);
         return thisTerm;
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 };
 
@@ -507,7 +511,7 @@ Term.prototype.eval = function(values) {
                 } else if(isInt(sub)) {
                     eval = Math.pow(sub, thisVar.degree);
                 } else {
-                    throw "InvalidArgument";
+                    throw Error("InvalidArgument");
                 }
             }
         }
@@ -641,7 +645,7 @@ var Variable = function(variable) {
         this.variable = variable;
         this.degree = 1;
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 };
 

--- a/src/fractions.js
+++ b/src/fractions.js
@@ -2,6 +2,18 @@ var isInt = require('./helper').isInt;
 var gcd = require('./helper').gcd;
 var lcm = require('./helper').lcm;
 
+Math.sign = Math.sign || function(x) {
+    if( +x === x ) { // check if a number was given
+        return (x === 0) ? x : (x > 0) ? 1 : -1;
+    }
+    return NaN;
+};
+
+Math.cbrt = Math.cbrt || function(x) {
+    var y = Math.pow(Math.abs(x), 1/3);
+    return x < 0 ? -y : y;
+};
+
 var Fraction = function(a, b) {
     if (b == 0) {
         throw "DivideByZero";
@@ -55,7 +67,7 @@ Fraction.prototype.add = function(f) {
         a = f;
         b = 1;
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 
     var copy = this.copy();
@@ -86,7 +98,7 @@ Fraction.prototype.subtract = function(f) {
     } else if (isInt(f)) {
         return copy.add(new Fraction(-f, 1));
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 };
 
@@ -103,7 +115,7 @@ Fraction.prototype.multiply = function(f) {
         a = 0;
         b = 1;
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 
     var copy = this.copy();
@@ -116,7 +128,7 @@ Fraction.prototype.multiply = function(f) {
 
 Fraction.prototype.divide = function(f) {
     if (f == 0) {
-        throw "DivideByZero";
+        throw Error("DivideByZero");
     }
 
     var copy = this.copy();
@@ -126,7 +138,7 @@ Fraction.prototype.divide = function(f) {
     } else if (isInt(f)) {
         return copy.multiply(new Fraction(1, f));
     } else {
-        throw "InvalidArgument";
+        throw Error("InvalidArgument");
     }
 };
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,133 @@
+var Expression = require('./expressions').Expression;
+var Fraction = require('./fractions');
+var Equation = require('./equations');
+
+var VARIABLE_REGEX = /^[a-zA-Z][a-zA-Z0-9]*$/g
+var EQUATION_REGEX = /^([^=]+)=([^=]+)$/g
+var EXPRESSION_REGEX = /^(?:([0-9]+|[+\-\*\/\^\(\)]|(?:[0-9]*[a-zA-Z][a-zA-Z0-9]*))\s*)+$/g
+
+var SUPPORTED_OPS = {
+    '^': function(expr1, expr2) {
+        return expr1.pow(expr2);
+    },
+    '*': function(expr1, expr2) {
+        return expr1.multiply(expr2);
+    },
+    '/': function(expr1, expr2) {
+        if(expr2 instanceof Expression && expr2.isConstant()) {
+            return expr1.divide(expr2.constant);    
+        }
+        return expr1.divide(expr2);    
+    },
+    '+': function(expr1, expr2) {
+        return expr1.add(expr2);    
+    },    
+    '-': function(expr1, expr2) {
+        return expr1.subtract(expr2);    
+    }
+}
+    
+var Parser = function() {
+};
+
+Parser.gobbleSpaces = function(expressionStr) {
+    while(expressionStr.length > 0 && expressionStr.charAt(0) == ' ') {
+        expressionStr = expressionStr.slice(1);
+    }
+    return expressionStr;
+};
+
+Parser.gobbleVariable = function(expressionStr) {
+    var match = expressionStr.match(/^[a-zA-Z][a-zA-Z0-9]*/);
+    expressionStr = expressionStr.slice(match[0].length);
+
+    var expression = new Expression(match[0]); 
+    return {
+        expression: expression,
+        expressionStr: expressionStr
+    };
+};
+
+Parser.gobbleNumeric = function(expressionStr) {
+    var match = expressionStr.match(/^[0-9]+/);
+    expressionStr = expressionStr.slice(match[0].length);
+       
+    var expression = new Expression(new Fraction(parseInt(match[0], 10), 1));
+    return {
+        expression: expression,
+        expressionStr: expressionStr
+    };
+}
+
+Parser.gobbleExpression = function(expressionStr) {
+    var expression;
+    
+    expressionStr = Parser.gobbleSpaces(expressionStr);
+    var exprChar = expressionStr.charAt(0);
+    if(exprChar == '(') {
+        var expression = Parser.parseExpression(expressionStr.substring(1));
+        // ')'
+        expression.expressionStr = expression.expressionStr.substring(1); 
+        
+    } else if (exprChar.match(/[a-z]/i)) {
+        expression = Parser.gobbleVariable(expressionStr);
+    } else if (exprChar.match(/\d/) || exprChar == '.') {    
+        expression = Parser.gobbleNumeric(expressionStr);
+    }
+    
+    return expression;
+};
+
+Parser.parseExpression = function(expressionStr) {
+    var expr1, op, expr2;
+
+    expr1 = Parser.gobbleExpression(expressionStr);
+    expressionStr = expr1.expressionStr;
+
+    expressionStr = Parser.gobbleSpaces(expressionStr);    
+    if(expressionStr.length == 0) {
+        return expr1;
+    }    
+    
+    var exprChar = expressionStr.charAt(0);    
+    if(exprChar == ')') {
+        return expr1;
+    }
+    
+    op = '*';    
+    if (SUPPORTED_OPS[exprChar]) {
+        op = exprChar;
+        expressionStr = expressionStr.slice(1);
+    }
+ 
+    expr2 = Parser.gobbleExpression(expressionStr);
+    expressionStr = expr2.expressionStr;
+  
+    return {
+        expression: SUPPORTED_OPS[op](expr1.expression, expr2.expression),
+        expressionStr: expressionStr
+    };
+}
+
+Parser.parse = function(expressionStr) {
+    if(typeof(expressionStr) === "string") {
+        if(expressionStr.match(VARIABLE_REGEX)) {
+            return new Expression(expressionStr);
+        } else if (expressionStr.match(EQUATION_REGEX)) {
+        
+            var equalMark = expressionStr.indexOf('=');
+            var lefthandExp = Parser.parse(expressionStr.substring(0, equalMark));
+            var righthandExp = Parser.parse(expressionStr.substring(equalMark+1));
+            
+            return new Equation(lefthandExp, righthandExp);
+        } else if (expressionStr.match(EXPRESSION_REGEX)) {
+            return Parser.parseExpression(expressionStr).expression;
+        }
+    }
+    throw Error("InvalidArgument: " + expressionStr);
+};
+
+
+module.exports = {
+    parse:  Parser.parse
+};

--- a/test/parser-spec.js
+++ b/test/parser-spec.js
@@ -1,0 +1,59 @@
+var Expression = require('../src/expressions').Expression;
+var Parser = require('../src/parser');
+
+describe("Normal behavior for non-parse case", function() {
+    var x1 = Parser.parse("x");
+    var x2 = Parser.parse("x2");
+    
+    it("should behave normally", function() {
+        expect(x1.toString()).toEqual("x");
+    });
+    
+    it("should treat x2 as variable x2 (and not 2*x)", function() {
+        expect(x2.toString()).toEqual("x2");
+    });    
+});
+
+describe("Simple parse behavior", function() {
+    var x1 = Parser.parse("2x");
+    var x2 = Parser.parse("x + 3");
+    var x3 = Parser.parse("5/4");
+    
+    it("should be interpreted as 2*x", function() {
+        expect(x1.toString()).toEqual("2x");
+    });
+    
+    it("should be interpreted as x + 3", function() {
+        expect(x2.toString()).toEqual("x + 3");
+    });
+    
+    it("should be interpreted as 5/4", function() {
+        expect(x3.toString()).toEqual("5/4");
+    });      
+});
+
+describe("Parentheses parse behavior", function() {
+    var x1 = Parser.parse("2(x + 3)");
+    var x2 = Parser.parse("(2x) + 3");
+    var x3 = Parser.parse("(((x + 3)))");
+    
+    it("should be interpreted as 2x + 6", function() {
+        expect(x1.toString()).toEqual("2x + 6");
+    }); 
+
+    it("should be interpreted as 2x + 3", function() {
+        expect(x2.toString()).toEqual("2x + 3");
+    }); 
+    
+    it("should be interpreted as x + 3", function() {
+        expect(x3.toString()).toEqual("x + 3");
+    });     
+});
+
+describe("Equation parse behavior", function() {
+    var x1 = Parser.parse("x=y");
+    
+    it("should be interpreted as x=y", function() {
+        expect(x1.toString()).toEqual("x = y");
+    });  
+});


### PR DESCRIPTION
This is a very basic parser, but it should handle any expression or equation.  It doesn't deal with operator precedence yet, so parentheses are required for situations like 3 + 5 * 4, otherwise it gets interpreted as (3 + 5) * 4.  

Also I defined Math.sign and Math.cbrt in fractions.js because jasmine had difficulty finding them.  Feel free to remove.  