### PR TITLE
Added implicit option to toString

### DIFF
--- a/src/equations.js
+++ b/src/equations.js
@@ -280,8 +280,8 @@ Equation.prototype.eval = function(values) {
     return new Equation(this.lhs.eval(values), this.rhs.eval(values));
 };
 
-Equation.prototype.toString = function() {
-    return this.lhs.toString() + " = " + this.rhs.toString();
+Equation.prototype.toString = function(options) {
+    return this.lhs.toString(options) + " = " + this.rhs.toString(options);
 };
 
 Equation.prototype.toTex = function() {

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -200,13 +200,13 @@ Expression.prototype.summation = function(variable, lower, upper, simplify) {
 	return newExpr;
 };
 
-Expression.prototype.toString = function() {
+Expression.prototype.toString = function(options) {
     var str = "";
 
     for (var i = 0; i < this.terms.length; i++) {
         var term = this.terms[i];
 
-        str += (term.coefficients[0].valueOf() < 0 ? " - " : " + ") + term.toString();
+        str += (term.coefficients[0].valueOf() < 0 ? " - " : " + ") + term.toString(options);
     }
 
     for (var i = 0; i < this.constants.length; i++) {
@@ -606,7 +606,8 @@ Term.prototype.sort = function() {
     return this;
 };
 
-Term.prototype.toString = function() {
+Term.prototype.toString = function(options) {
+    var implicit = options && options.implicit;
     var str = "";
 
     for (var i = 0; i < this.coefficients.length; i++) {
@@ -616,8 +617,13 @@ Term.prototype.toString = function() {
             str += " * " + coef.toString();
         }
     }
-
-    str = this.variables.reduce(function(p,c){return p.concat(c.toString());},str);
+    str = this.variables.reduce(function (p, c) {
+        if (implicit && !!p) {
+            var vStr = c.toString();
+            return !!vStr ? p + "*" + vStr : p;
+        } else
+            return p.concat(c.toString());
+    }, str);
     str = (str.substring(0, 3) === " * " ? str.substring(3, str.length) : str);
     str = (str.substring(0, 1) === "-" ? str.substring(1, str.length) : str);
 

--- a/test/equation-spec.js
+++ b/test/equation-spec.js
@@ -399,3 +399,20 @@ describe("Equation evaluation", function() {
         expect(answer.toString()).toEqual("y + 4 = 2");
     });
 });
+
+describe("An equation toString should accept options", function() {
+    var a = new Expression("a");
+    var b = new Expression("b");
+    var c = new Expression("c");
+    var d = new Expression("d");
+
+    var eq = new Equation(a.multiply(b), c.multiply(d));
+
+    it("implicit should be disabled", function() {
+        expect(eq.toString()).toEqual("ab = cd");
+    });
+
+    it("implicit should be applied to both expressions", function() {
+        expect(eq.toString({implicit: true})).toEqual("a*b = c*d");
+    });
+});

--- a/test/expression-spec.js
+++ b/test/expression-spec.js
@@ -403,7 +403,7 @@ describe("Expression printing to string", function() {
         expect(x.toString()).toEqual("x");
     });
 
-    it("should only print the constant if all the other terms have been canceled out", function() {
+    it("should only print the constant if all the other terms have been cancelled out", function() {
         var x = new Expression("x");
         var y = new Expression("y");
 
@@ -413,6 +413,16 @@ describe("Expression printing to string", function() {
         var answer = expr1.subtract(expr2); // x + y - 3 - (x + y) = -3
 
         expect(answer.toString()).toEqual("-3");
+    });
+
+    it("should allows you to pass in options", function() {
+        var x = new Expression("x");
+        var y = new Expression("y");
+        var z = new Expression("z");
+
+        x = x.multiply(y).subtract(z.multiply(x)).add(5); // x*y - z*y + 5
+
+        expect(x.toString({implicit: true})).toEqual("x*y - z*x + 5");
     });
 });
 
@@ -443,7 +453,7 @@ describe("Expression printing to tex", function() {
         expect(x.toTex()).toEqual("x");
     });
 
-    it("should only print the constant if all the other terms have been canceled out", function() {
+    it("should only print the constant if all the other terms have been cancelled out", function() {
         var x = new Expression("x");
         var y = new Expression("y");
 
@@ -603,7 +613,7 @@ describe("Expression evaluation with multiple variables - crossproducts", functi
     });
 });
 
-describe("Expression evaulation with other expressions", function() {
+describe("Expression evaluation with other expressions", function() {
     it("works with no coefficient", function() {
        var x = new Expression("x").add(2);   // x + 2
        var sub = new Expression("y").add(4); // y + 4

--- a/test/term-spec.js
+++ b/test/term-spec.js
@@ -310,3 +310,44 @@ describe("Term printing to TeX", function() {
         expect(z.toTex()).toEqual("\\frac{9}{10}x");
     });
 });
+
+describe("Term printing to to string", function() {
+    it("implicit should be disabled by default", function() {
+        var x = new Variable("x");
+        var y = new Variable("y");
+        var t = new Term(x);
+
+        t = t.multiply(new Term(y)); // x*y
+
+        expect(t.toString()).toEqual("xy");
+    });
+
+    it("implicit should add * between variables", function() {
+        var x = new Variable("x");
+        var y = new Variable("y");
+        var t = new Term(x);
+
+        t = t.multiply(new Term(y)); // x*y
+
+        expect(t.toString({implicit: true})).toEqual("x*y");
+    });
+
+    it("implicit should add * between the coefficient and the variables", function() {
+        var x = new Variable("x");
+        var t = new Term(x);
+
+        t = t.multiply(3); // 3*x
+
+        expect(t.toString({implicit: true})).toEqual("3*x");
+    });
+
+    it("implicit should ignore a variable with degree 0", function() {
+        var x = new Variable("x");
+        x.degree = 0;
+        var t = new Term(x);
+
+        t = t.multiply(3).multiply(new Term(new Variable("y"))); // 3*(x^0)*y
+
+        expect(t.toString({implicit: true})).toEqual("3*y");
+    });
+});


### PR DESCRIPTION
The `toString` accepts an `implicit` option to show the multiplication symbol `*` between the variables.

This PR closes #70 