### PR TITLE
fix expressions for expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 _site
 .DS_Store
 coverage
+package-lock.json

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -3,7 +3,7 @@ var isInt = require('./helper').isInt;
 var GREEK_LETTERS = require('./helper').GREEK_LETTERS;
 
 var ExpressionError = function ExpressionError (variable) {
-  let error;
+  var error;
   error = new TypeError();
 
   error.message = "Invalid Argument (" + variable.toString() + "): Argument must be of type String, Integer, Fraction or Term.";

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -2,6 +2,16 @@ var Fraction = require('./fractions');
 var isInt = require('./helper').isInt;
 var GREEK_LETTERS = require('./helper').GREEK_LETTERS;
 
+var ExpressionError = function ExpressionError (variable) {
+  let error;
+  error = new TypeError();
+
+  error.message = "Invalid Argument (" + variable.toString() + "): Argument must be of type String, Integer, Fraction or Term.";
+  error.name = 'ExpressionError';
+
+  return error;
+};
+
 var Expression = function(variable) {
     this.constants = [];
 
@@ -20,7 +30,7 @@ var Expression = function(variable) {
     } else if(typeof(variable) === "undefined") {
         this.terms = [];
     }else{
-        throw new TypeError("Invalid Argument (" + variable.toString() + "): Argument must be of type String, Integer, Fraction or Term.");
+        throw new ExpressionError(variable);
     }
 };
 


### PR DESCRIPTION
when setting an erroneous code, throwing a freshly created (type)error message does not display well.
consider the following line of code:
``` js
new algebra.Expression(new Fraction(1,1))
```

## old output
pay special attention to the second line of the codeblock.
``` js
$ node source/cas
C:\Users\Francis\Documents\Projects\app\node_modules\algebra.js\src\expressions.js:23
        throw new TypeError("Invalid Argument (" + variable.toString() + "): Argument must be of type String, Integer, Fraction or Term.");
        ^

TypeError: Invalid Argument (0): Argument must be of type String, Integer, Fraction or Term.
    at new Expression (C:\Users\Francis\Documents\Projects\app\node_modules\algebra.js\src\expressions.js:23:15)
    at mean (C:\Users\Francis\Documents\Projects\app\source\cas.js:72:16)
    at Object.<anonymous> (C:\Users\Francis\Documents\Projects\app\source\cas.js:86:13)
    at Module._compile (module.js:641:30)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
    at tryModuleLoad (module.js:503:12)
    at Function.Module._load (module.js:495:3)
    at Function.Module.runMain (module.js:682:10)
    at startup (bootstrap_node.js:191:16)
```

## New output
the same line is much cleaner and closer to what a user would expect; the actually `ExpressionError:` line is still the same.
``` js
C:\Users\Francis\Documents\GitHub\algebra.js\src\expressions.js:33                                
        throw new ExpressionError(variable);                                                      
        ^                                                                                         
                                                                                                  
ExpressionError: Invalid Argument (7): Argument must be of type String, Integer, Fraction or Term.
    at new ExpressionError (C:\Users\Francis\Documents\GitHub\algebra.js\src\expressions.js:7:11) 
    at new Expression (C:\Users\Francis\Documents\GitHub\algebra.js\src\expressions.js:33:15)     
    at mean (C:\Users\Francis\Documents\Projects\app\source\cas.js:78:16)                         
    at Object.<anonymous> (C:\Users\Francis\Documents\Projects\app\source\cas.js:86:13)           
    at Module._compile (module.js:641:30)                                                         
    at Object.Module._extensions..js (module.js:652:10)                                           
    at Module.load (module.js:560:32)                                                             
    at tryModuleLoad (module.js:503:12)                                                           
    at Function.Module._load (module.js:495:3)                                                    
    at Function.Module.runMain (module.js:682:10)                                                 
```